### PR TITLE
Rewrite Gamba to only use enabled outcomes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -286,7 +286,7 @@
         "twitch_fragments/outcomes/farts.lua": "2edf28b445aa789547b5c6566eff1e4e04dfa6e9bb34001757ed76f8b250e069",
         "twitch_fragments/outcomes/fire_trap.lua": "408c1995a313d82440f39ec30df9b04a405da738061cc92503a32ed4fd7f2fb1",
         "twitch_fragments/outcomes/full_health.lua": "68af766fd239e236e5823918df3a7e0f8be15974a15c8e4e8818dd9331d4625a",
-        "twitch_fragments/outcomes/gamba.lua": "534cefafb9ceee9b56b018c7015a3b2847391e686ccc64e83a61762856d460c3",
+        "twitch_fragments/outcomes/gamba.lua": "94f01b99ec37ee8d08ca8e41d12e46977d1dffcdf1eac5d43c21161f168fde98",
         "twitch_fragments/outcomes/gift_spell.lua": "616f1326cd871d5521bec4d8ba633503f758edc5decd15e19acd6dda256829b4",
         "twitch_fragments/outcomes/glue_curse.lua": "7fc0d3a0a03a3b1b7d183570bc75171c9315cc1529fba5afbed885712b8a4de2",
         "twitch_fragments/outcomes/gold_rush.lua": "319a29ba2a28515487a94dfe2ff92d33fe6547012d8d6c154a1fdc995784bbd7",

--- a/twitch_fragments/outcomes/gamba.lua
+++ b/twitch_fragments/outcomes/gamba.lua
@@ -2,17 +2,56 @@
 --Lucky... or maybe not x2?
 --unknown
 --20
---yeehaw
+--Picks two more outcomes at random
 function twitch_gamba()
-    local outcome = ti_outcomes[math.random(1, #ti_outcomes)]
-    local outcome2 = ti_outcomes[math.random(1, #ti_outcomes)]
-    while outcome2.id == outcome.id do
-        outcome2 = ti_outcomes[math.random(1, #ti_outcomes)]
-    end
-    local name = outcome.name .. " & " .. outcome2.name
-    GamePrintImportant(name, "whoa")
-    GamePrint("GAMBA: " .. name)
-    outcome.fn()
-    outcome2.fn()
+    local outcome_count = 2
 
+    -- just a little more randomness...
+    if math.random(1000) == 1 then
+        outcome_count = outcome_count + math.random(2)
+    end
+
+    -- pre-filtering avoids looping an unknown number of times
+    local possible_outcomes = {}
+    for _, outcome in ipairs(ti_outcomes) do
+        if outcome.enabled then
+            table.insert(possible_outcomes, outcome)
+        end
+    end
+
+    -- avoid infinite loop (edge case)
+    if #possible_outcomes <= outcome_count then
+        for i, outcome in ipairs(possible_outcomes) do
+            if outcome.id == "gamba" then
+                table.remove(possible_outcomes, i)
+            end
+        end
+    end
+
+    if #possible_outcomes == 0 then
+        GamePrintImportant("Nothing", "whoa")
+        return
+    end
+
+    local gamba_outcomes = {}
+    local gamba_names = {}
+
+    for i = 1, outcome_count do
+        local index = math.random(1, #possible_outcomes)
+        local outcome = possible_outcomes[index]
+        if outcome ~= nil then
+            table.remove(possible_outcomes, index) -- avoid duplicates
+            table.insert(gamba_outcomes, outcome) -- to call functions after showing message
+            table.insert(gamba_names, outcome.name)
+        end
+    end
+
+    gamba_names = table.concat(gamba_names, " & ")
+    GamePrintImportant(gamba_names, "whoa")
+    GamePrint("GAMBA: " .. gamba_names)
+
+    -- call function after showing message, so that the message order is correct if Gamba is chosen by Gamba
+    for _, outcome in ipairs(gamba_outcomes) do
+        outcome.fn()
+    end
 end


### PR DESCRIPTION
Random selection uses a list of only the remaining possible outcomes, avoiding potential infinite loops.
If no outcomes are available, the message with the outcome names says "Nothing".
The way it is implemented also handles outcome counts other than 2 (which is how only one other enabled outcome is handled, instead of entering an infinite loop).