### PR TITLE
Makes ANYTHING able to be stolen by Possess Wands vote

### DIFF
--- a/files/scripts/steal_wand.lua
+++ b/files/scripts/steal_wand.lua
@@ -6,29 +6,45 @@ local pos_x, pos_y = EntityGetTransform(victim)
 local inventory = EntityGetFirstComponentIncludingDisabled(victim, "Inventory2Component")
 if inventory ~= nil then
     local active_item = ComponentGetValue2(inventory, "mActualActiveItem")
-    if active_item ~= nil then
-        if EntityHasTag(active_item, "wand") or EntityHasTag(active_item, "item_pickup") then
+    if active_item ~= nil and active_item ~= 0 then
+        -- if EntityHasTag(active_item, "wand") or EntityHasTag(active_item, "item_pickup") or EntityHasTag(active_item, "tablet") then  -- Keeping this if statement here in case we wanna revert anything
+            ComponentSetValue2(inventory, "mForceRefresh", true)
             EntityRemoveFromParent(active_item)
             EntitySetComponentsWithTagEnabled(active_item,"enabled_in_hand",false)
-            EntitySetComponentsWithTagEnabled(active_item,"enabled_in_world",true)
-            --EntityKill(active_item)
+            EntitySetComponentsWithTagEnabled(active_item,"enabled_in_world",true) -- spawn item/wand
+            -- EntityKill(active_item)
             ComponentSetValue2(inventory, "mActualActiveItem", 0)
             ComponentSetValue2(inventory, "mActiveItem", 0)
 
             if EntityHasTag(active_item, "wand") then -- spawn wand ghost
                 EntityLoad("mods/Twitch-integration/files/entities/animals/wand_ghost.xml", pos_x, pos_y)
             end
-            EntitySetTransform(active_item, pos_x, pos_y) -- spawn item/wand
-            if EntityHasTag(active_item, "item_pickup") then -- throw item
+            EntitySetTransform(active_item, pos_x, pos_y)
+            if not EntityHasTag(active_item, "wand") then -- throw item
                 local velcomp_victim = EntityGetFirstComponentIncludingDisabled(victim, "VelocityComponent")
                 if velcomp_victim ~= nil then
                     local vel_x, vel_y = ComponentGetValue2(velcomp_victim, "mVelocity")
                     PhysicsApplyForce(active_item, vel_x*50, vel_y*25-125)
                     PhysicsApplyTorque(active_item, 0.5+vel_x*5)
                 end
+                -- TODO: Fix the code breaking the kick function of items
+
+                -- activate thrown item functionality
+                for _,comp in ipairs(EntityGetComponentIncludingDisabled(active_item, "LuaComponent") or {}) do
+                    local script_throw = ComponentGetValue2(comp, "script_throw_item")
+                    if script_throw and script_throw ~= "" then
+                        print("manually throwing!")
+                        local GetUpdatedEntityID_old = GetUpdatedEntityID
+                        GetUpdatedEntityID = function() return active_item end
+                        dofile_once(script_throw)
+                        throw_item(pos_x, pos_y, pos_x, pos_y-50)
+                        GetUpdatedEntityID = GetUpdatedEntityID_old
+                        break
+                    end
+                end
             end
             --EntityAddChild(wand, active_item)
-        end
+        -- end
     end
 end
 

--- a/files/scripts/steal_wand.lua
+++ b/files/scripts/steal_wand.lua
@@ -22,10 +22,12 @@ if inventory ~= nil then
             EntitySetTransform(active_item, pos_x, pos_y)
             if not EntityHasTag(active_item, "wand") then -- throw item
                 local velcomp_victim = EntityGetFirstComponentIncludingDisabled(victim, "VelocityComponent")
-                if velcomp_victim ~= nil then
+                local bodycomp = EntityGetFirstComponentIncludingDisabled(active_item, "PhysicsBodyComponent")
+                if velcomp_victim ~= nil and bodycomp ~= nil then
                     local vel_x, vel_y = ComponentGetValue2(velcomp_victim, "mVelocity")
-                    PhysicsApplyForce(active_item, vel_x*50, vel_y*25-125)
-                    PhysicsApplyTorque(active_item, 0.5+vel_x*5)
+                    local mPixelCount = ComponentGetValue2(bodycomp, "mPixelCount")
+                    PhysicsApplyForce(active_item, vel_x*2*mPixelCount, (vel_y*mPixelCount)-(5*mPixelCount))
+                    PhysicsApplyTorque(active_item, mPixelCount/10+vel_x*(mPixelCount/5))
                 end
                 -- TODO: Fix the code breaking the kick function of items
 

--- a/files/scripts/steal_wand.lua
+++ b/files/scripts/steal_wand.lua
@@ -27,7 +27,7 @@ if inventory ~= nil then
                     local vel_x, vel_y = ComponentGetValue2(velcomp_victim, "mVelocity")
                     local mPixelCount = ComponentGetValue2(bodycomp, "mPixelCount")
                     PhysicsApplyForce(active_item, vel_x*2*mPixelCount, (vel_y*mPixelCount)-(5*mPixelCount))
-                    PhysicsApplyTorque(active_item, mPixelCount/10+vel_x*(mPixelCount/5))
+                    PhysicsApplyTorque(active_item, mPixelCount/13+vel_x*(mPixelCount/5))
                 end
                 -- TODO: Fix the code breaking the kick function of items
 

--- a/manifest.json
+++ b/manifest.json
@@ -213,7 +213,7 @@
         "files/scripts/proj_slowdown_20.lua": "c69212409bdde0f59c46d153db05403dd1dfdc323ded2d087f132a789fc5e9a5",
         "files/scripts/projectiles/darkflame_fake.lua": "8ff1663ba08e6c77c8b1dbe05da9a53f762280b0e38504db25366ac1d12ee51a",
         "files/scripts/standard_warning.lua": "e8ed723ef5a3847773e1dc0886b774935b714253e69580448eadec0eb28f8a67",
-        "files/scripts/steal_wand.lua": "a933ffac04bfaa84ea87cc6d94e215ffb334ad34348c411ed3efd066de032202",
+        "files/scripts/steal_wand.lua": "2660aab0057bb7b3b51392683678d213d7a12132eb3924dbb0f50fc8d90e61d9",
         "files/scripts/stealwand_distance_delete.lua": "dec34b51d56ff6a375b725707d090ae76b89e61ac3a8722839c4be70a107a145",
         "files/scripts/stealwand_emptyhands.lua": "4b7071293c5d979d02b3cbf278c05f2cb9f51555ed1af6e352ae8126bfc518fd",
         "files/scripts/status_effects/anti_homing_shot.lua": "7906d67f9b643ecc4c6ee9a31740a040058b751d831d4b73929c4f015bffb164",

--- a/manifest.json
+++ b/manifest.json
@@ -213,7 +213,7 @@
         "files/scripts/proj_slowdown_20.lua": "c69212409bdde0f59c46d153db05403dd1dfdc323ded2d087f132a789fc5e9a5",
         "files/scripts/projectiles/darkflame_fake.lua": "8ff1663ba08e6c77c8b1dbe05da9a53f762280b0e38504db25366ac1d12ee51a",
         "files/scripts/standard_warning.lua": "e8ed723ef5a3847773e1dc0886b774935b714253e69580448eadec0eb28f8a67",
-        "files/scripts/steal_wand.lua": "cca4ee4c6c0e1b2b74e2e8df78f25443c7492fbded795f069d5e8906a8d01dd6",
+        "files/scripts/steal_wand.lua": "a933ffac04bfaa84ea87cc6d94e215ffb334ad34348c411ed3efd066de032202",
         "files/scripts/stealwand_distance_delete.lua": "dec34b51d56ff6a375b725707d090ae76b89e61ac3a8722839c4be70a107a145",
         "files/scripts/stealwand_emptyhands.lua": "4b7071293c5d979d02b3cbf278c05f2cb9f51555ed1af6e352ae8126bfc518fd",
         "files/scripts/status_effects/anti_homing_shot.lua": "7906d67f9b643ecc4c6ee9a31740a040058b751d831d4b73929c4f015bffb164",

--- a/manifest.json
+++ b/manifest.json
@@ -213,7 +213,7 @@
         "files/scripts/proj_slowdown_20.lua": "c69212409bdde0f59c46d153db05403dd1dfdc323ded2d087f132a789fc5e9a5",
         "files/scripts/projectiles/darkflame_fake.lua": "8ff1663ba08e6c77c8b1dbe05da9a53f762280b0e38504db25366ac1d12ee51a",
         "files/scripts/standard_warning.lua": "e8ed723ef5a3847773e1dc0886b774935b714253e69580448eadec0eb28f8a67",
-        "files/scripts/steal_wand.lua": "2660aab0057bb7b3b51392683678d213d7a12132eb3924dbb0f50fc8d90e61d9",
+        "files/scripts/steal_wand.lua": "f96b81b7ef39d4eebed6adc00d776afa6df210e0d0da97b48568e82e165f498d",
         "files/scripts/stealwand_distance_delete.lua": "dec34b51d56ff6a375b725707d090ae76b89e61ac3a8722839c4be70a107a145",
         "files/scripts/stealwand_emptyhands.lua": "4b7071293c5d979d02b3cbf278c05f2cb9f51555ed1af6e352ae8126bfc518fd",
         "files/scripts/status_effects/anti_homing_shot.lua": "7906d67f9b643ecc4c6ee9a31740a040058b751d831d4b73929c4f015bffb164",


### PR DESCRIPTION
...ok, let's try this again.

This allows anything to be stolen via the Possess Wands vote, including tablets and books. These previously were unable to be stolen.

This also makes it where stolen items with a throw function has that function activated, such as kammis, runestones, and broken wands.

The only issue left here is that stolen items have their kick functions rendered unusable until they are picked up and thrown again normally. The two items this is notable for are runestones and sadekivis. This is a deeper issue running in the way the item is spawned into the world from the inventory; Horscht's mod Inventory Bags has this same issue, and neither of us know how to fix it.