### PR TITLE
Fix upgrade enemies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -423,7 +423,7 @@
         "update.js": "bdc68c213786748d597b1800bcae733c294161d5e0797adbcfb364ebe5240732",
         "webui/index.html": "fe1e877ad7805a1feb6a97bac5f430a2b3b8eca8c014d8d80224652f15ede635",
         "webui/js/main.js": "e94c50d0127b03d5182b44925371c2a7e4f37aa91d45072c4378300ec0d8b642",
-        "twitch_fragments/outcomes/upgrade_enemies.lua" : "559FB1CED30016B1003F6903D971B20E21BEF4B2D02FB579C4A4C44F628921F3",
+        "twitch_fragments/outcomes/upgrade_enemies.lua" : "98C2477C4E944DE18FA02B992E08AC6B0AFAE74BFBA9157D173E73B3C314768F",
         "files/effects/upgrade_enemies.xml" : "340DB8B3EC9294A60758E0C20C6C9BEC52FFF154A1A115E678CD0EDB3B1DDBE6",
         "files/effects/upgrade_enemies.lua" : "83F0C4A7EAA6BB5A8FE8F0E191C8333424D20A1958C06488919277A91FE8B3FB",
         "files/effects/status_icons/enemy_upgrade.png" :"47d92702942e3920276e0be188dcead7b51e102d5f387a3642fdbfc7d81bc5cc",

--- a/twitch_fragments/outcomes/upgrade_enemies.lua
+++ b/twitch_fragments/outcomes/upgrade_enemies.lua
@@ -1,3 +1,8 @@
+--Upgrade Enemies
+--Some enemies feel different...
+--curses
+--68
+--todo
 function twitch_upgrade_enemies()
     async(effect_upgrade_enemies)
 end


### PR DESCRIPTION
Deleted the comments at the top of upgrade_enemies.lua at some point, this re-adds them