### PR TITLE
Moneyshot buff

### DIFF
--- a/files/effects/moneyshot_effect.lua
+++ b/files/effects/moneyshot_effect.lua
@@ -2,16 +2,24 @@ function shot(shot_id)
     local entity_id = GetUpdatedEntityID()
     local x, y = EntityGetTransform(entity_id)
     local owner = EntityGetClosestWithTag(x, y, "mortal")
-
+    local moneyToRemove = 5
+    local dmgPercent = 0.03
     local wallet_component = EntityGetFirstComponent(owner, "WalletComponent")
     if (wallet_component) then
         local money = tonumber(ComponentGetValue2(wallet_component, "money"))
-        if (money > 3) then
-            ComponentSetValue2(wallet_component, "money", money - 3)
+        if (money >= moneyToRemove) then
+            ComponentSetValue2(wallet_component, "money", money - moneyToRemove)
             local projectile_component = EntityGetFirstComponent(shot_id, "ProjectileComponent")
             if (projectile_component ~= nil) then
                 local damage = tonumber(ComponentGetValue2(projectile_component, "damage"))
                 ComponentSetValue2(projectile_component, "damage", damage + 0.4)
+            end
+        else 
+            local dmg_model = EntityGetFirstComponent(owner, "DamageModelComponent")
+            if dmg_model then
+                local max_hp = ComponentGetValue2(dmg_model, "max_hp")
+                local dmg = max_hp * dmgPercent
+                EntityInflictDamage(owner,dmg,"DAMAGE_CURSE","Bad financial decisions",0, 0, 0,entity_id)
             end
         end
     end

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
         "files/effects/earthquake_curse.xml": "fde9ba88f517d92236cdda78ace1722b14ae0c465a15bf979cc02001ae91070e",
         "files/effects/farts.xml": "530e90ed67d40cf80baa511a979b1ab1b7fd6567123936278659e1fc2f91cffe",
         "files/effects/mana_overdrive.xml": "dbfb9d14978b9e2eb76c9cbee0f3d5a1ea412c3a7a15867a09a5abcef56b7047",
-        "files/effects/moneyshot_effect.lua": "46db733e19da6883af60aa3ce9d61a04aba268f69ce75caec8864199605a93bf",
+        "files/effects/moneyshot_effect.lua": "0fbba42f4330ca80cb569abd262f374a816d2185bbd85d347f5aac46266bdce7",
         "files/effects/moneyshot_end.lua": "63f900b9f72afecda924fe2d409568ff9c9e86b4bd93a35432c69db3e6ec24d2",
         "files/effects/moneyshot_start.lua": "2286bdac7cd12afa4a840b8413e8b30586c8615f7e019a59f7d85b3ba7a64fbd",
         "files/effects/moneyshot.xml": "e9bc24a44090cc3162928fd584c07602e2a39a094c3703893de5e5cca68c4c1a",


### PR DESCRIPTION
Was looking through some of the less-used outcomes and thought I'd try to buff some of them, so here is money shot, now it removes 5 gold instead of 3, and deals 3% of the players maximum HP if the player is too poor.
Hopefully no manifest issues.