### PR TITLE
Clean up vote selection

### DIFF
--- a/lib/_jsdoc.js
+++ b/lib/_jsdoc.js
@@ -1,0 +1,56 @@
+/**
+ * @typedef {Object} RandomVotingTime
+ * @property {boolean} enabled
+ * @property {number} min
+ * @property {number} max
+ * @property {boolean} randomize
+ */
+
+/**
+ * @typedef {Object} RandomTimeBetween
+ * @property {boolean} enabled
+ * @property {number} min
+ * @property {number} max
+ */
+
+/**
+ * @typedef {Object} OptionType
+ * @property {string} name
+ * @property {number} rarity
+ */
+
+/**
+ * @typedef {Object} NoitaSettings
+ * @property {boolean} enabled
+ * @property {boolean} game_ui
+ * @property {boolean} obs_overlay
+ * @property {boolean} display_votes
+ * @property {boolean} random_on_no_votes
+ * @property {boolean} named_enemies
+ * @property {boolean} scuffed_mode
+ * @property {boolean} multiple_winners
+ * @property {number} time_between_votes
+ * @property {number} voting_time
+ * @property {number} options_per_vote
+ * @property {RandomVotingTime} random_voting_time
+ * @property {RandomTimeBetween} random_time_between
+ * @property {OptionType[]} option_types
+ * @property {boolean} permanent_gamba_option
+ */
+
+/**
+ * @typedef {Object} Outcome
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} enabled
+ * @property {string} comment
+ * @property {string} description
+ * @property {string} type
+ * @property {number} rarity
+ */
+
+/**
+ * @typedef {Object} OutcomeGroup
+ * @property {number} rarity
+ * @property {Outcome[]} outcomes
+ */

--- a/lib/noita.js
+++ b/lib/noita.js
@@ -1,6 +1,20 @@
 const ws = require("ws")
 const fs = require("fs")
 const path = require("path")
+
+/** @typedef {require('./_jsdoc').NoitaSettings} NoitaSettings */
+/** @typedef {require('./_jsdoc').Outcome} Outcome */
+
+/**
+ * @typedef {Object} OutcomeGroup
+ * @property {number} rarity
+ * @property {Outcome[]} outcomes
+ */
+
+/**
+ * @typedef {Outcome & {votes: number}} VotableOutcome
+ */
+
 class Outcomes {
     constructor(parent) {
         this.parent = parent
@@ -8,50 +22,133 @@ class Outcomes {
         this.loadOutcomes()
     }
 
+    /** @returns {Record<string, Outcome>} */
     get settings() {
         return this.parent.settings.get("outcomes")
     }
 
-    drawByType(num, types) {
-        const outcomes = this.getOutcomes()
-        const gamba_option = outcomes.gamba
-        gamba_option.votes = 0
-        const permanent_gamba_option = this.parent.settings.get("noita").permanent_gamba_option
-        if (permanent_gamba_option) delete outcomes.gamba
-        const options = Object.values(outcomes)
-        const enabled_options = {}
-        options.forEach((val) => {
-            if (val.enabled) {
-                if (typeof enabled_options[val.type] == "undefined") { enabled_options[val.type] = [] }
-                enabled_options[val.type].push(val)
-            }
-        })
-        const counter = {}
-        for (let i = 1 + Number(permanent_gamba_option); i <= num;) {
-            let type = this.pickRandom(types)
-            if (typeof counter[type.name] == "undefined") {
-                counter[type.name] = 0
-            }
-            if (typeof enabled_options[type.name] !== "undefined" && enabled_options[type.name].length > counter[type.name]) {
-                counter[type.name] += 1
-                i++
-            }
-        }
-        let final = []
-        for (const option of Object.keys(counter)) {
-            for (let i = 0; i < counter[option]; i++) {
-                final.push(this.pickRandom(enabled_options[option], true))
-            }
+    /**
+     * Pick an item out of an array, using the `rarity` property
+     * to bias the distribution
+     *
+     * @param {{rarity: number}[]} options
+     * @returns {number}
+     */
+    pickRandomIdx(options) {
+        let sum = options.reduce((accumulator, val) => accumulator + val.rarity, 0)
+        let rand = Math.floor(Math.random() * sum)
+        let total = 0
+        let idx = 0
+
+        while (total < sum) {
+            total += options[idx].rarity
+            if (total > rand) break
+            idx++
         }
 
-        final = JSON.parse(JSON.stringify(final)).map(val => {
-            val.votes = 0
-            return val
-        }).sort((a, b) => {
-            return a.name.length - b.name.length
-        })
-        if (permanent_gamba_option) final.push(JSON.parse(JSON.stringify(gamba_option)))
-        return final
+        return idx
+    }
+
+    /**
+     * Get the pool of votable outcomes, ready to draw from, and any
+     * selections that are forced by the game settings
+     */
+    getPool() {
+        /** @type {NoitaSettings} settings */
+        const settings = this.parent.settings.get('noita')
+        /** @type {Outcome[]} */
+        const outcomes = Object.values(this.parent.settings.get('outcomes'))
+
+        // temporarily key by outcome type, so we can more directly
+        // place the outcomes as we produce them
+
+        /** @type {Map<string, OutcomeGroup>}  */
+        const poolByTypeName = new Map()
+        for (const optionType of settings.option_types) {
+            if (optionType.rarity <= 0) continue
+            poolByTypeName.set(
+                optionType.name,
+                {
+                    rarity: optionType.rarity,
+                    outcomes: []
+                }
+            )
+        }
+
+        /** @type {Outcome[]} */
+        const selected = []
+        for (const outcome of outcomes) {
+            // forced outcomes ignore rarity and enabled setting. it would
+            // be more confusing to check "permanent gamba option" and have
+            // it not show up because the outcome was disabled than the reverse
+            if (outcome.id === 'gamba' && settings.permanent_gamba_option) {
+                selected.push(outcome)
+                continue
+            }
+
+            // the specific outcome is disabled
+            if (!outcome.enabled) continue
+
+            // the rarity is set to something invalid treat as disabled
+            if (outcome.rarity <= 0) continue
+
+            // the whole category doesn't exist -- is disabled
+            if (!poolByTypeName.has(outcome.type)) continue
+
+            poolByTypeName.get(outcome.type).outcomes.push(outcome)
+        }
+
+        return {
+            selected,
+            // convert to an array for easier selection. remove any empty groups
+            pool: [...poolByTypeName.values()].filter(group => group.outcomes.length > 0)
+        }
+    }
+
+    /**
+     * Draw `num` outcomes from the voting pool and return an array of
+     * the resultant selections. The returned objects are safe to mutate
+     * and initialized with a property `.votes` = 0
+     *
+     * @param {number} num
+     */
+    drawByType(num) {
+        // previous code put forced gamba at the end. due to the way things
+        // are set up, and providing for the ability to gracefully handle
+        // various edge cases, forced items are produced by `getPool` and
+        // now go at the start. we fill the rest of the selections with
+        // random selections.
+
+        const {selected, pool} = this.getPool()
+        for (let i = selected.length; i < num; i++) {
+            // if we've run out of things to draw, there's nothing we can do
+            // go with whatever we have accumulated so far
+            if (pool.length === 0) break
+
+            // pick a category to draw from
+            const groupIdx = this.pickRandomIdx(pool)
+            const group = pool[groupIdx].outcomes
+
+            // if there's only one left, take the only remaining outcome
+            // and remove the whole group
+            if (group.length === 1) {
+                selected.push(group[0])
+                pool.splice(groupIdx, 1)
+                continue
+            }
+
+            // pick an item from the group
+            const outcomeIdx = this.pickRandomIdx(group)
+            selected.push(group[outcomeIdx])
+            group.splice(outcomeIdx, 1)
+        }
+
+        // since the rest of the code mutates this data instead of keeping its
+        // own state, we'll create new objects whose prototype is our selected
+        // outcome. this lets us assign 'votes' without mutating our source data
+        return selected.map(outcome => /** @type {VotableOutcome} */ (
+            Object.assign({}, outcome, {votes: 0}))
+        )
     }
 
     getOutcomes() {
@@ -102,38 +199,6 @@ class Outcomes {
             lua += data + "\n"
         }
         return lua
-    }
-
-    pickRandom(options, trim = false) {
-        let sum = options.reduce((accumulator, val) => accumulator + val.rarity, 0)
-        let rand = Math.random() * sum
-        let total = 0
-        let lastIdx = -1
-        let selectedIdx = null
-
-        for (let i in options) {
-            let rarity = options[i].rarity
-            total += rarity
-            if (rarity > 0) {
-                if (rand <= total) {
-                    selectedIdx = i
-                    break
-                }
-                lastIdx = i
-            }
-
-            if (i === options.length - 1) {
-                selectedIdx = lastIdx
-            }
-        }
-
-        let result = options[selectedIdx]
-
-        if (trim) {
-            options.splice(selectedIdx, 1)
-        }
-
-        return result
     }
 }
 
@@ -332,9 +397,9 @@ class Noita {
         const obsFile = path.join(__dirname, "../voteHistory.txt")
 		fs.appendFile(obsFile, text + '\n', 'utf8', function (err) {
 			if (err) {
-				console.error("Error appending to the file:", err);
+				console.error("Error appending to the file:", err)
 			}
-		});
+		})
     }
     getWinner() {
         //scuffed_mode


### PR DESCRIPTION
> Likely addresses some statistical edge cases, but more generally just cleans up the code to be easier to reason about, more efficient, and to be more certain that the apparent intent of how outcomes are selected is the actual reality

Figured that since I had already written the code, I might as well send a PR. However, I'm not set up to test that the mod from a user perspective, and I removed the jank `JSON.parse(JSON.stringify())` deep clone in favor of just writing code that doesn't mutate the input data.

So, I don't recommend just YOLO merging it - someone will need to make sure that things still work like normal.

I also added JSDoc -- though VSCode won't warn about type errors unless you throw `// @ts-check` at the top of the file, and not everything is fully type-safe. But I did use it to check for problems in the code I changed.

---

Background:

Due to Dunk's coping, I got nerd sniped into solving how to actually calculate the expected probability of a given outcome to show up on any single vote. I was eventually successful, and with both dunk's and yolk's posted settings, my calculations came out as:

```
comparing conga_forced_checkpoint:
  dunk: 9.177% [13 draws]
  yolk: 10.866% [15 draws]
```

As a check against this, I ran an empirical sampling script that used TI's own code to run 10,000 simulated votes and count the number of times forced checkpoint showed up. I ran that five times and got the following results:

```
conga_forced_checkpoint (10000 samples):
  dunk: 9.30%
  yolk: 10.57%

conga_forced_checkpoint (10000 samples):
  dunk: 9.62%
  yolk: 10.33%

conga_forced_checkpoint (10000 samples):
  dunk: 9.14%
  yolk: 10.70%

conga_forced_checkpoint (10000 samples):
  dunk: 9.29%
  yolk: 10.50%

conga_forced_checkpoint (10000 samples):
  dunk: 9.48%
  yolk: 10.76%
```

I observed that the empirical values were slightly different than the expected values, but close enough that it likely wasn't an error in my statistical calculations. In an attempt to validate that, I rewrote `drawByType` to see if it changed. It did:

```
conga_forced_checkpoint (10000 samples):
  dunk: 9.00%
  yolk: 10.69%

conga_forced_checkpoint (10000 samples):
  dunk: 9.05%
  yolk: 9.88%

conga_forced_checkpoint (10000 samples):
  dunk: 8.72%
  yolk: 11.11%

conga_forced_checkpoint (10000 samples):
  dunk: 9.16%
  yolk: 10.94%

conga_forced_checkpoint (10000 samples):
  dunk: 9.12%
  yolk: 11.08%
```

The variance seemed a bit high, so I tried bumping the number of samples. The old code ran too slowly at 100k samples, but the new code handled it just fine:

```
conga_forced_checkpoint (100000 samples):
  dunk: 9.08%
  yolk: 10.82%

conga_forced_checkpoint (100000 samples):
  dunk: 9.05%
  yolk: 10.88%

conga_forced_checkpoint (100000 samples):
  dunk: 9.16%
  yolk: 10.85%

conga_forced_checkpoint (100000 samples):
  dunk: 9.08%
  yolk: 10.91%

conga_forced_checkpoint (100000 samples):
  dunk: 9.20%
  yolk: 10.90%
```

These numbers are more in line with what I expect to see by the math.

---